### PR TITLE
If no prefix, use empty string

### DIFF
--- a/bin/svgstore
+++ b/bin/svgstore
@@ -18,7 +18,7 @@ var argv_options = {
 var args = yargs(process.argv.slice(2), argv_options);
 
 var output = args.output;
-var prefix = args.prefix;
+var prefix = args.prefix || '';
 var inline = args.inline;
 var inputs = [];
 


### PR DESCRIPTION
To avoid icons with id “undefinedname”
