### PR TITLE
Fix compatibility with Node 14

### DIFF
--- a/bin/svgstore
+++ b/bin/svgstore
@@ -45,7 +45,7 @@ var sprites = inputs.reduce(function(sprites, file) {
 
 // Output to file, or to stdout
 if (output) {
-    fs.writeFileSync(output, sprites);
+    fs.writeFileSync(output, sprites.toString({ inline: inline }));
 } else {
     console.log(sprites.toString({ inline: inline }));
 }


### PR DESCRIPTION
Fixes `TypeError [ERR_INVALID_ARG_TYPE]: The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView. Received an instance of Object` when running in NodeJS 14.

This is safe for a patch release (since this is already what we do when outputting to the console).