### PR TITLE
Update yargs-parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   },
   "homepage": "https://github.com/svgstore/svgstore-cli#readme",
   "dependencies": {
-    "glob": "^7.0.5",
-    "svgstore": "^2.0.2",
-    "yargs-parser": "^5.0.0"
+    "glob": "^7.1.6",
+    "svgstore": "^2.0.3",
+    "yargs-parser": "^18.0.0"
   }
 }


### PR DESCRIPTION
Breaking: This drops support for NodeJS 4.x. I'm not sure exactly what the new minimum version of NodeJS is...

This resolves the `npm audit` warning about prototype pollution coming from yargs-parser.